### PR TITLE
Fixed template compiling

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,22 +1,60 @@
-const pug = require('pug')
-const bem = require('pug-bem')
-const loaderUtils = require('loader-utils')
+var path = require('path')
+var dirname = path.dirname
+var loaderUtils = require('loader-utils')
+var nodeResolve = require('resolve').sync
+var bem = require('pug-bem')
 
 module.exports = function (source) {
+  var modulePaths = {}
+  modulePaths.pug = require.resolve('pug')
+  modulePaths.runtime = nodeResolve('pug-runtime', {
+    basedir: dirname(modulePaths.pug)
+  })
 
-  const options = Object.assign({
-    filename: this.resourcePath,
-    doctype: 'html',
-    plugins: [bem],
-    compileDebug: this.debug || false
-  }, loaderUtils.getOptions(this))
+  var pug = require(modulePaths.pug)
+  var req = loaderUtils.getRemainingRequest(this).replace(/^!/, '')
+  var query = loaderUtils.getOptions(this) || {}
 
-  bem.b = options.b || bem.b
-  bem.e = options.e || bem.e
-  bem.m = options.m || bem.m
+  var loaderContext = this
 
-  const template = pug.compile(source, options)
-  template.dependencies.forEach(this.addDependency)
+  run()
+  function run() {
+    var options = Object.assign(
+      {
+        filename: req,
+        doctype: query.doctype || 'html',
+        pretty: query.pretty,
+        self: query.self,
+        compileDebug: loaderContext.debug || false,
+        globals: ['require'].concat(query.globals || []),
+        name: 'template',
+        inlineRuntimeFunctions: false,
+        filters: query.filters,
+        plugins: [bem].concat(query.plugins || [])
+      },
+      query
+    )
 
-  return template(options.data || {})
+    bem.b = query.b || bem.b
+    bem.e = query.e || bem.e
+    bem.m = query.m || bem.m
+
+    try {
+      var tmplFunc = pug.compileClient(source, options)
+    } catch (e) {
+      loaderContext.callback(e)
+      return
+    }
+    var runtime =
+      'var pug = require(' +
+      loaderUtils.stringifyRequest(
+        loaderContext,
+        '!' + modulePaths.runtime
+      ) +
+      ');\n\n'
+    loaderContext.callback(
+      null,
+      runtime + tmplFunc.toString() + ';\nmodule.exports = template;'
+    )
+  }
 }


### PR DESCRIPTION
Replaced the call of the template renderer function making it look like the original pug-loader to make it possible:

1. to call require function from pug templates
2. to render templates without connecting the original pug-loader
3. to fix piped text which is located along with include directive